### PR TITLE
Add module skeletons and tests

### DIFF
--- a/lma/__init__.py
+++ b/lma/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for the Linux Multimodal Assistant.
+
+This package provides modules that interface with various system
+components such as audio input, clipboard management and mouse
+control. It also exposes client code for communicating with large
+language models. Modules contain minimal placeholders for future
+implementation.
+"""
+
+__all__ = []

--- a/lma/assistant.py
+++ b/lma/assistant.py
@@ -1,0 +1,18 @@
+"""Main interface for the Linux Multimodal Assistant.
+
+This module will orchestrate various components such as hotkey
+listeners, speech transcribers and large language model clients.
+Future implementations will expose a class that coordinates these
+services.
+"""
+
+class Assistant:
+    """Placeholder assistant class."""
+
+    def __init__(self) -> None:
+        """Initialize the assistant."""
+        pass
+
+    def run(self) -> None:
+        """Run the assistant main loop."""
+        pass

--- a/lma/clipboard.py
+++ b/lma/clipboard.py
@@ -1,0 +1,16 @@
+"""Clipboard management utilities.
+
+Functions in this module will interact with the system clipboard to
+retrieve and set text or other data formats. Future implementations may
+use `pyperclip` or platform specific commands.
+"""
+
+
+def get_clipboard() -> str:
+    """Return the current clipboard contents."""
+    return ""
+
+
+def set_clipboard(text: str) -> None:
+    """Set the clipboard contents."""
+    _ = text

--- a/lma/hotkey_listener.py
+++ b/lma/hotkey_listener.py
@@ -1,0 +1,18 @@
+"""Hotkey listener for triggering assistant actions.
+
+This module will monitor global keyboard shortcuts. When specific
+hotkeys are pressed, the listener will notify the assistant to perform
+an action. Implementation will depend on system libraries such as
+`pynput` or `keyboard`.
+"""
+
+class HotkeyListener:
+    """Placeholder hotkey listener."""
+
+    def start(self) -> None:
+        """Start listening for hotkeys."""
+        pass
+
+    def stop(self) -> None:
+        """Stop listening for hotkeys."""
+        pass

--- a/lma/keyboard_injector.py
+++ b/lma/keyboard_injector.py
@@ -1,0 +1,17 @@
+"""Keyboard event injection utilities.
+
+This module will allow the assistant to programmatically type text or
+send keyboard shortcuts. Future implementations may rely on `pyautogui`
+or `pynput`.
+"""
+
+class KeyboardInjector:
+    """Placeholder keyboard injector."""
+
+    def type_text(self, text: str) -> None:
+        """Simulate typing text on the keyboard."""
+        _ = text
+
+    def send_hotkey(self, *keys: str) -> None:
+        """Send a keyboard shortcut."""
+        _ = keys

--- a/lma/llm_client.py
+++ b/lma/llm_client.py
@@ -1,0 +1,16 @@
+"""Client interface for large language models.
+
+This module will provide a minimal API wrapper around local or remote
+LLM backends. Implementations may include HTTP requests or library
+bindings to frameworks like HuggingFace transformers.
+"""
+
+from typing import Any
+
+
+class LLMClient:
+    """Placeholder LLM client."""
+
+    def send_prompt(self, prompt: str) -> Any:
+        """Send a prompt to the language model and return a response."""
+        return None

--- a/lma/mic_capture.py
+++ b/lma/mic_capture.py
@@ -1,0 +1,17 @@
+"""Microphone audio capture utilities.
+
+Provides an interface for recording audio from the system microphone.
+Future implementations may use libraries such as `pyaudio` or
+`sounddevice` to stream audio data for transcription.
+"""
+
+class MicrophoneCapture:
+    """Placeholder microphone capture handler."""
+
+    def start(self) -> None:
+        """Begin capturing audio."""
+        pass
+
+    def stop(self) -> None:
+        """Stop capturing audio."""
+        pass

--- a/lma/mouse_controller.py
+++ b/lma/mouse_controller.py
@@ -1,0 +1,17 @@
+"""Mouse control utilities for automation.
+
+In the future this module may use `pyautogui` or similar libraries to
+simulate mouse movement and clicks. Currently it provides a placeholder
+class interface.
+"""
+
+class MouseController:
+    """Placeholder mouse controller."""
+
+    def move(self, x: int, y: int) -> None:
+        """Move the mouse to the given coordinates."""
+        pass
+
+    def click(self) -> None:
+        """Perform a mouse click."""
+        pass

--- a/lma/notifier.py
+++ b/lma/notifier.py
@@ -1,0 +1,13 @@
+"""User notification utilities.
+
+This module will provide functionality for displaying desktop
+notifications or other alerts to the user. Libraries such as
+`notify2` or native system calls may be used.
+"""
+
+class Notifier:
+    """Placeholder notifier implementation."""
+
+    def send(self, message: str) -> None:
+        """Send a notification to the user."""
+        _ = message

--- a/lma/screenshot.py
+++ b/lma/screenshot.py
@@ -1,0 +1,13 @@
+"""Utilities for capturing screenshots.
+
+This module will provide functionality for grabbing the current screen
+contents. Libraries such as `pyautogui` or `mss` may be used in the
+future to implement cross-platform screenshot capability.
+"""
+
+from typing import Any
+
+
+def take_screenshot() -> Any:
+    """Placeholder function for taking a screenshot."""
+    return None

--- a/lma/security.py
+++ b/lma/security.py
@@ -1,0 +1,11 @@
+"""Security related helpers for the assistant.
+
+This module will hold functions related to permissions checking and
+sandboxing of assistant actions. These will help ensure that automation
+features do not inadvertently compromise system security.
+"""
+
+
+def check_permissions() -> bool:
+    """Placeholder permission check."""
+    return True

--- a/lma/transcribe.py
+++ b/lma/transcribe.py
@@ -1,0 +1,13 @@
+"""Audio transcription utilities.
+
+This module will include functions for converting recorded audio into
+text. A speech recognition backend such as Whisper or Vosk may be
+integrated here in the future.
+"""
+
+from typing import Iterable
+
+
+def transcribe_audio(frames: Iterable[bytes]) -> str:
+    """Placeholder for an audio transcription routine."""
+    return ""

--- a/lma/utils.py
+++ b/lma/utils.py
@@ -1,0 +1,10 @@
+"""General utility functions used across modules.
+
+Placeholders for common helpers such as timing or configuration loading
+are included here to aid future development.
+"""
+
+
+def placeholder() -> None:
+    """Do nothing placeholder function."""
+    pass

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,24 @@
+"""Ensure core modules are importable."""
+
+import importlib
+
+MODULES = [
+    "lma.assistant",
+    "lma.hotkey_listener",
+    "lma.mic_capture",
+    "lma.screenshot",
+    "lma.transcribe",
+    "lma.clipboard",
+    "lma.llm_client",
+    "lma.mouse_controller",
+    "lma.keyboard_injector",
+    "lma.notifier",
+    "lma.security",
+    "lma.utils",
+]
+
+
+def test_module_imports():
+    for name in MODULES:
+        module = importlib.import_module(name)
+        assert module is not None


### PR DESCRIPTION
## Summary
- scaffold modules for future assistant features
- add placeholder implementations
- ensure modules are importable via simple test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2d074c18832e871efe0c8462f369