### PR TITLE
Add configuration template and dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Linux-Multimodal-Assistant
 Linux Multimodal Assistant
+
+## Installation
+
+1. Create a Python virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `config.json` and adjust values to match your system.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,20 @@
+{
+  "llm": {
+    "provider": "openai",
+    "endpoint": "http://localhost:8000/v1",
+    "model": "gpt-3.5-turbo",
+    "api_key": "changeme"
+  },
+  "transcription": {
+    "provider": "whispercpp",
+    "model_path": "/path/to/ggml-base.bin"
+  },
+  "tts": {
+    "provider": "piper-tts",
+    "voice": "en_US"
+  },
+  "hotkeys": {
+    "activate": "ctrl+alt+space"
+  },
+  "screenshot_dir": "./screenshots"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+httpx
+whispercpp
+faster-whisper
+pyautogui
+piper-tts
+pynput
+pyperclip
+mss
+sounddevice
+notify2


### PR DESCRIPTION
## Summary
- add a `config.json` template for runtime settings
- record optional packages in `requirements.txt`
- document installation steps in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2eb73d9c832e8565ed1f7f5ae3f5