### PR TITLE
Add pytest and placeholder tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ Linux Multimodal Assistant
    pip install -r requirements.txt
    ```
 3. Copy `config.json` and adjust values to match your system.
+
+## Running Tests
+
+After installing the dependencies you can run the automated test suite
+using `pytest`:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyperclip
 mss
 sounddevice
 notify2
+pytest

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_llm_client_placeholder():
+    assert True

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_screenshot_placeholder():
+    assert True

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_security_placeholder():
+    assert True

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_transcribe_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- add placeholder tests for transcribe, llm client, screenshot and security modules
- setup pytest as a dev dependency
- document running the tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2f5c2894832e8ff9bfdd28f1adf5